### PR TITLE
Add setting to block external images

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ php composer.phar install
 
 1. First of all you need to protect the access to your domain. if it will be public. We recomend create a .htaccess/.htpassword files to add an extra layer of security. 
 2. Config one mail on the **mail.config.sample.php**, rename to **mail.config.php** and check the connection con ./cron_mail.php.
-3. Test the folder imap structure with **cron_mail_test.php**
-3. Start fetching your mails, navigate and tag them all!
-4. Create task or favorite your preferred mails.
+3. In that file you can set `$display_remote_images` to `0` to avoid loading external images when reading mails.
+4. Test the folder imap structure with **cron_mail_test.php**
+5. Start fetching your mails, navigate and tag them all!
+6. Create task or favorite your preferred mails.
 
 _For more examples, please refer to the [Documentation](https://backupmail.iguannaweb.com?go=docs)_
 

--- a/igw_includes/config/mail.config.sample.php
+++ b/igw_includes/config/mail.config.sample.php
@@ -39,7 +39,15 @@ $correos_config=array(
 		'imap_spam' => 'Imap_spam_folder',
 		'oauth_token' => '1/0', //keep it in 0
 		'imap_extra_folders' => array('folder_1','folder_2','folder_3'),
-		'archive_mail' => '1/0'
-	)
+        'archive_mail' => '1/0'
+        )
 );
+
+// Display external images inside emails. Set to '1' to allow downloading
+// remote images or '0' to block them for privacy reasons.
+$display_remote_images = '0';
+
+// Array of allowed remote image base URLs. Leave empty to block all
+// external images when $display_remote_images is '0'.
+$allowed_image_urls = array();
 ?>

--- a/igw_includes/functions/functions.php
+++ b/igw_includes/functions/functions.php
@@ -377,7 +377,31 @@ function get_stats(){
 
     
   }
-  return $count_stats; 
+  return $count_stats;
+}
+
+function remove_external_images($html, $allowed = array()){
+  $dom = new DOMDocument();
+  libxml_use_internal_errors(true);
+  $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+  libxml_clear_errors();
+  $imgs = $dom->getElementsByTagName('img');
+  // Using while loop because live NodeList will change when removing nodes
+  for($i = $imgs->length - 1; $i >= 0; $i--){
+    $img = $imgs->item($i);
+    $src = $img->getAttribute('src');
+    $allowed_flag = false;
+    foreach($allowed as $allowed_url){
+      if(strpos($src, $allowed_url) === 0){
+        $allowed_flag = true;
+        break;
+      }
+    }
+    if(!$allowed_flag && preg_match('/^https?:\/\//i', $src)){
+      $img->parentNode->removeChild($img);
+    }
+  }
+  return $dom->saveHTML();
 }
 
 

--- a/mail_reader.php
+++ b/mail_reader.php
@@ -48,11 +48,19 @@ $htmlEmbedded = $parser->getMessageBody('htmlEmbedded');
 // return the html version with the embedded contents like images
 
 if($_GET["t"]=="htmlplus"){
-	echo ''.$htmlEmbedded.'';
+        $content = $htmlEmbedded;
 }elseif($_GET["t"]=="html"){
-	echo ''.$html.'';
+        $content = $html;
 }elseif($_GET["t"]=="text"){
-	echo ''.nl2br($text).'';
+        $content = nl2br($text);
+}
+
+if(isset($content)){
+        if($_GET["t"]=="text" || $display_remote_images === '1'){
+                echo ''.$content.'';
+        }else{
+                echo ''.remove_external_images($content, $allowed_image_urls).'';
+        }
 }
 
 }


### PR DESCRIPTION
## Summary
- add `$display_remote_images` configuration with allow list
- sanitize external images based on new configuration
- document the new setting in `README`

## Testing
- `php -l mail_reader.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff05258dc8333a0c6e787c2e178c4