### PR TITLE
Add warning for blocked remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ php composer.phar install
 
 1. First of all you need to protect the access to your domain. if it will be public. We recomend create a .htaccess/.htpassword files to add an extra layer of security. 
 2. Config one mail on the **mail.config.sample.php**, rename to **mail.config.php** and check the connection con ./cron_mail.php.
-3. In that file you can set `$display_remote_images` to `0` to avoid loading external images when reading mails.
+3. In that file you can set `$display_remote_images` to `0` to avoid loading external images when reading mails. When images are blocked, a small alert lists the domains that were removed.
 4. Test the folder imap structure with **cron_mail_test.php**
 5. Start fetching your mails, navigate and tag them all!
 6. Create task or favorite your preferred mails.

--- a/igw_includes/functions/functions.php
+++ b/igw_includes/functions/functions.php
@@ -380,6 +380,35 @@ function get_stats(){
   return $count_stats;
 }
 
+function get_blocked_image_sources($html, $allowed = array()){
+  $blocked = array();
+  $dom = new DOMDocument();
+  libxml_use_internal_errors(true);
+  $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+  libxml_clear_errors();
+  $imgs = $dom->getElementsByTagName('img');
+  for($i = 0; $i < $imgs->length; $i++){
+    $img = $imgs->item($i);
+    $src = $img->getAttribute('src');
+    $allowed_flag = false;
+    foreach($allowed as $allowed_url){
+      if(strpos($src, $allowed_url) === 0){
+        $allowed_flag = true;
+        break;
+      }
+    }
+    if(!$allowed_flag && preg_match('/^https?:\/\//i', $src)){
+      $host = parse_url($src, PHP_URL_HOST);
+      if($host !== null && $host !== ''){
+        $blocked[] = $host;
+      }
+    }
+  }
+  $blocked = array_unique($blocked);
+  sort($blocked);
+  return $blocked;
+}
+
 function remove_external_images($html, $allowed = array()){
   $dom = new DOMDocument();
   libxml_use_internal_errors(true);

--- a/mail_reader.php
+++ b/mail_reader.php
@@ -59,6 +59,10 @@ if(isset($content)){
         if($_GET["t"]=="text" || $display_remote_images === '1'){
                 echo ''.$content.'';
         }else{
+                $blocked_domains = get_blocked_image_sources($content, $allowed_image_urls);
+                if(!empty($blocked_domains)){
+                        echo '<div class="alert alert-warning fade show small">Remote images from '.implode(', ', $blocked_domains).' were blocked.</div>';
+                }
                 echo ''.remove_external_images($content, $allowed_image_urls).'';
         }
 }


### PR DESCRIPTION
## Summary
- show which domains images were blocked from
- collect blocked domains with `get_blocked_image_sources`
- warn users when images are blocked in mail_reader
- document remote image blocking message

## Testing
- `php -l igw_includes/functions/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffb06faf48333a2c4d4b7870d6e67